### PR TITLE
Resolve AppDrawerItem's href to suppress prop type warning

### DIFF
--- a/src/layout/AppDrawerItem.tsx
+++ b/src/layout/AppDrawerItem.tsx
@@ -5,6 +5,8 @@ import {
   ListItem,
 } from '@mui/material';
 import NextLink, { NextLinkProps } from '@/routing/NextLink';
+import Router from 'next/router';
+import { resolveHref } from 'next/dist/shared/lib/router/utils/resolve-href';
 
 type AppDrawerItemProps = Pick<NextLinkProps, 'href'> & {
   icon?: React.ReactNode;
@@ -15,7 +17,7 @@ type AppDrawerItemProps = Pick<NextLinkProps, 'href'> & {
 function AppDrawerItem({ href, icon, title, selected }: AppDrawerItemProps) {
   return (
     <ListItem disablePadding>
-      <ListItemButton href={href} component={NextLink} selected={selected}>
+      <ListItemButton href={resolveHref(Router, href, false)} component={NextLink} selected={selected}>
         {icon && <ListItemIcon>{icon}</ListItemIcon>}
         <ListItemText primary={title} />
       </ListItemButton>


### PR DESCRIPTION
I was getting a prop type warning for the genre links in the app drawer.  It seemed to be working totally fine, but I wanted to suppress the error.

<img width="868" alt="image" src="https://github.com/onderonur/tmdb-explorer/assets/648035/74a4a5c8-210b-4a3b-bbfc-360b30582aa2">

This may not be the best solution, but it's a solution.  Use the Router to resolve the href from a URL object.